### PR TITLE
Fixed regular expression causing "undefined is not an object (evaluating 'display.index')"

### DIFF
--- a/spaces.jsx
+++ b/spaces.jsx
@@ -38,7 +38,7 @@ export const render = ({ output }, ...args) => {
       </div>
     );
   }
-  const displayId = Number(window.location.pathname.replace(/\//g, ''));
+  const displayId = Number(window.location.pathname.replace(/\D+/g, ''));
   const display = data.displays.find(d => d.id === displayId);
   return (
     <div style={style}>


### PR DESCRIPTION
I had the same issue as #12 and was able to fix it on my system. 

The regular expression used to find the current displayId was leaving behind some characters making displays undefined.

I changed the regex from '/\//g' to '/\D+/g' which has fixed the error for me, and hopefully is a suitable fix.

---

Closes #12 